### PR TITLE
Focus search input

### DIFF
--- a/src/nav/SearchBox.jsx
+++ b/src/nav/SearchBox.jsx
@@ -84,6 +84,7 @@ function SearchBox() {
             value={text}
             style={style}
             fullWidth
+            inputRef={input => input && input.focus()}
         />
     )
 }


### PR DESCRIPTION
This PR auto-focuses the search input.  I always find myself wanting to immediately search for a specific lock so I thought this would be helpful and not mess up anything.