### PR TITLE
Entry+list tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,12 @@ scripts/*.md
 /stats.html
 public/version.json
 public/sitemap.txt
+package-lock.json
+vite-project/counter.js
+vite-project/index.html
+vite-project/javascript.svg
+vite-project/main.js
+vite-project/package.json
+vite-project/public/vite.svg
+vite-project/style.css
+yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -28,12 +28,3 @@ scripts/*.md
 /stats.html
 public/version.json
 public/sitemap.txt
-package-lock.json
-vite-project/counter.js
-vite-project/index.html
-vite-project/javascript.svg
-vite-project/main.js
-vite-project/package.json
-vite-project/public/vite.svg
-vite-project/style.css
-yarn.lock

--- a/src/entries/Entry.jsx
+++ b/src/entries/Entry.jsx
@@ -70,9 +70,8 @@ function Entry({entry, expanded, onExpand}) {
                 <BeltStripe value={entry.belt}/>
                 <div style={{margin: '12px 0px 0px 8px', width: '55%', flexShrink: 0, flexDirection: 'column'}}>
                     <FieldValue
-                        // name='Make / Model'
+                        {/* Make/Model */}
                         value={makeModels}
-                        // textStyle={entry.belt === 'Unranked' ? {color: '#aaa'} : {}}
                         textStyle={entry.belt === 'Unranked' ? {color: '#aaa', marginLeft: '0px'} : {marginLeft: '0px'}}
                     />
 
@@ -89,7 +88,7 @@ function Entry({entry, expanded, onExpand}) {
                     {
                         entry.lockingMechanisms?.length > 0 &&
                         <FieldValue
-                        	//name='Locking Mechanisms'
+                        	{/* Locking Mechanisms */}
                         	value={<Stack direction='row' spacing={0} sx={{flexWrap: 'wrap'}}>
                                 {entry.lockingMechanisms?.map((lockingMechanism, index) =>
                                     <FilterChip
@@ -109,7 +108,7 @@ function Entry({entry, expanded, onExpand}) {
                     <AccordionDetails sx={{padding: '8px 16px 0px 16px'}}>
                         <Stack direction='row' spacing={1} sx={{width: '100%', flexWrap: 'wrap'}}>
                             <FieldValue
-                              //name='Belt'
+                              {/* Belt */}
                               style={{width: '50%', marginLeft: '0px'}} value={
                                 <React.Fragment>
                                     <Typography style={{marginLeft: '0px', fontSize: '1rem', lineHeight: 1.25, fontWeight: 500}}>
@@ -163,7 +162,7 @@ function Entry({entry, expanded, onExpand}) {
                         {
                             !!entry.media?.length &&
                             <FieldValue
-                              //name='Media'
+                              {/* Media */}
                               value={
                                 <ImageGallery entry={entry}/>
                             }/>

--- a/src/entries/Entry.jsx
+++ b/src/entries/Entry.jsx
@@ -56,7 +56,7 @@ function Entry({entry, expanded, onExpand}) {
         return (
             <Stack direction='column' spacing={0} sx={{flexWrap: 'wrap'}}>
                 {entry.makeModels?.map(({make, model}, index) =>
-                    <Typography key={index} style={{fontWeight: 500}}>
+                    <Typography key={index} style={{fontWeight: 500, fontSize: '1.07rem', lineHeight: 1.25, marginBottom: '6px'}}>
                         {make && make !== model ? `${make} ${model}` : model}
                     </Typography>
                 )}
@@ -68,27 +68,29 @@ function Entry({entry, expanded, onExpand}) {
         <Accordion expanded={expanded} onChange={handleChange} style={style} ref={ref}>
             <AccordionSummary expandIcon={<ExpandMoreIcon/>}>
                 <BeltStripe value={entry.belt}/>
-                <div style={{marginRight: 8, width: '50%', flexShrink: 0, flexDirection: 'column'}}>
+                <div style={{margin: '12px 0px 0px 0px', width: '55%', flexShrink: 0, flexDirection: 'column'}}>
                     <FieldValue
-                        name='Make / Model'
+                        // name='Make / Model'
                         value={makeModels}
-                        textStyle={entry.belt === 'Unranked' ? {color: '#aaa'} : {}}
+                        // textStyle={entry.belt === 'Unranked' ? {color: '#aaa'} : {}}
+                        textStyle={entry.belt === 'Unranked' ? {color: '#aaa', marginLeft: '0px'} : {marginLeft: '0px'}}
                     />
 
                     {
                         !!entry.version &&
                         <FieldValue
                             name='Version'
-                            value={<Typography>{entry.version}</Typography>}
+                            value={<Typography style={{fontSize: '0.95rem', lineHeight: 1.25}}>{entry.version}</Typography>}
                             textStyle={entry.belt === 'Unranked' ? {color: '#aaa'} : {}}
                         />
                     }
                 </div>
-                <div style={{width: '50%', flexShrink: 0, flexDirection: 'column'}}>
+                <div style={{margin: '8px 0px 0px 0px', width: '40%', flexShrink: 0, flexDirection: 'column'}}>
                     {
                         entry.lockingMechanisms?.length > 0 &&
-                        <FieldValue name='Locking Mechanisms' value={
-                            <Stack direction='row' spacing={0} sx={{flexWrap: 'wrap'}}>
+                        <FieldValue
+                        	//name='Locking Mechanisms'
+                        	value={<Stack direction='row' spacing={0} sx={{flexWrap: 'wrap'}}>
                                 {entry.lockingMechanisms?.map((lockingMechanism, index) =>
                                     <FilterChip
                                         key={index}
@@ -104,12 +106,19 @@ function Entry({entry, expanded, onExpand}) {
             {
                 expanded &&
                 <React.Fragment>
-                    <AccordionDetails>
+                    <AccordionDetails sx={{padding: '8px 16px 0px 16px'}}>
                         <Stack direction='row' spacing={1} sx={{width: '100%', flexWrap: 'wrap'}}>
-                            <FieldValue name='Belt' style={{width: '45%'}} value={
+                            <FieldValue
+                              //name='Belt'
+                              style={{width: '50%', marginLeft: '0px'}} value={
                                 <React.Fragment>
-                                    <Typography>
-                                        {entry.belt} {danPoints > 0 && ` (${danPoints} Dan Point${danPoints > 1 ? 's' : ''})`}
+                                    <Typography style={{marginLeft: '0px', fontSize: '1rem', lineHeight: 1.25, fontWeight: 500}}>
+                                        {entry.belt} 
+                                        {danPoints > 0
+                                        ? ` (${danPoints} Dan P${danPoints < 2 ? `oint` 
+                                        	: danPoints > 10 ? `ts` : `oints`})`
+                                        : entry.belt==`Unranked` ? ``
+                                        : ` Belt` }
                                     </Typography>
                                     <BeltIcon value={entry.belt} style={{marginBottom: -10}}/>
                                 </React.Fragment>
@@ -128,15 +137,6 @@ function Entry({entry, expanded, onExpand}) {
                                     </Typography>
                                 }/>
                             }
-                            {!!entry.relatedIds &&
-                                <FieldValue name='Other Versions' style={{width: '45%'}} value={
-                                    <React.Fragment>
-                                        {entry.relatedIds.map(relatedId =>
-                                            <RelatedEntryButton key={relatedId} id={relatedId}/>
-                                        )}
-                                    </React.Fragment>
-                                }/>
-                            }
                         </Stack>
                         {!!entry.features?.length &&
                             <FieldValue name='Features' value={
@@ -151,9 +151,20 @@ function Entry({entry, expanded, onExpand}) {
                                 </Stack>
                             }/>
                         }
+                            {!!entry.relatedIds &&
+                                <FieldValue name='Other Versions' value={
+                                    <React.Fragment>
+                                        {entry.relatedIds.map(relatedId =>
+                                            <RelatedEntryButton key={relatedId} id={relatedId}/>
+                                        )}
+                                    </React.Fragment>
+                                }/>
+                            }
                         {
                             !!entry.media?.length &&
-                            <FieldValue name='Media' value={
+                            <FieldValue
+                              //name='Media'
+                              value={
                                 <ImageGallery entry={entry}/>
                             }/>
                         }

--- a/src/entries/Entry.jsx
+++ b/src/entries/Entry.jsx
@@ -68,7 +68,7 @@ function Entry({entry, expanded, onExpand}) {
         <Accordion expanded={expanded} onChange={handleChange} style={style} ref={ref}>
             <AccordionSummary expandIcon={<ExpandMoreIcon/>}>
                 <BeltStripe value={entry.belt}/>
-                <div style={{margin: '12px 0px 0px 0px', width: '55%', flexShrink: 0, flexDirection: 'column'}}>
+                <div style={{margin: '12px 0px 0px 8px', width: '55%', flexShrink: 0, flexDirection: 'column'}}>
                     <FieldValue
                         // name='Make / Model'
                         value={makeModels}

--- a/src/entries/Entry.jsx
+++ b/src/entries/Entry.jsx
@@ -70,7 +70,6 @@ function Entry({entry, expanded, onExpand}) {
                 <BeltStripe value={entry.belt}/>
                 <div style={{margin: '12px 0px 0px 8px', width: '55%', flexShrink: 0, flexDirection: 'column'}}>
                     <FieldValue
-                        {/* Make/Model */}
                         value={makeModels}
                         textStyle={entry.belt === 'Unranked' ? {color: '#aaa', marginLeft: '0px'} : {marginLeft: '0px'}}
                     />
@@ -88,7 +87,6 @@ function Entry({entry, expanded, onExpand}) {
                     {
                         entry.lockingMechanisms?.length > 0 &&
                         <FieldValue
-                        	{/* Locking Mechanisms */}
                         	value={<Stack direction='row' spacing={0} sx={{flexWrap: 'wrap'}}>
                                 {entry.lockingMechanisms?.map((lockingMechanism, index) =>
                                     <FilterChip
@@ -108,7 +106,6 @@ function Entry({entry, expanded, onExpand}) {
                     <AccordionDetails sx={{padding: '8px 16px 0px 16px'}}>
                         <Stack direction='row' spacing={1} sx={{width: '100%', flexWrap: 'wrap'}}>
                             <FieldValue
-                              {/* Belt */}
                               style={{width: '50%', marginLeft: '0px'}} value={
                                 <React.Fragment>
                                     <Typography style={{marginLeft: '0px', fontSize: '1rem', lineHeight: 1.25, fontWeight: 500}}>
@@ -162,7 +159,6 @@ function Entry({entry, expanded, onExpand}) {
                         {
                             !!entry.media?.length &&
                             <FieldValue
-                              {/* Media */}
                               value={
                                 <ImageGallery entry={entry}/>
                             }/>

--- a/src/entries/FieldValue.jsx
+++ b/src/entries/FieldValue.jsx
@@ -17,7 +17,7 @@ function FieldValue({name, value, last, style, headerStyle = {}, textStyle = {}}
     return (
         <div style={marginStyle}>
             <div style={fullHeaderStyle}>
-                {name}:
+                {name}
             </div>
             <div style={fullTextStyle}>
                 {value}

--- a/src/entries/ImageGallery.jsx
+++ b/src/entries/ImageGallery.jsx
@@ -63,7 +63,7 @@ function ImageGallery({entry}) {
                     onClose={handleClose}
                 />
             }
-            <ImageList variant='masonry' cols={isMobile ? 2 : 3} sx={{marginTop: 0}}>
+            <ImageList variant='masonry' cols={isMobile ? 2 : 3} sx={{marginTop: 2}}>
                 {entry.media.map(({title, subtitle, thumbnailUrl, fullUrl, subtitleUrl}, index) =>
                     <ImageListItem key={index} style={{marginBottom: 8}}>
                         <img

--- a/src/info/BeltRequirements.jsx
+++ b/src/info/BeltRequirements.jsx
@@ -26,9 +26,9 @@ function BeltRequirements({belt}) {
         <Accordion expanded={expanded === 'beltreqs'} onChange={handleExpand} style={style}>
             <AccordionSummary expandIcon={<ExpandMoreIcon/>}>
                 <BeltStripe value={belt}/>
-                <Typography variant='h6'>{belt} Belt Requirements</Typography>
+                <Typography variant='h6' style={{margin: '0px 0px 0px 12px'}}>{belt} Belt Requirements</Typography>
             </AccordionSummary>
-            <AccordionDetails>
+            <AccordionDetails style={{margin: '0px 0px 0px 12px'}}>
                 <ReactMarkdown>
                     {markdown}
                 </ReactMarkdown>


### PR DESCRIPTION

[entry+list-changes 2023-12-05.zip](https://github.com/Lockpickers-United/lpu-belt-explorer/files/13572585/entry%2Blist-changes.2023-12-05.zip)
**PROPOSED DISPLAY CHANGES** (Screenshots TK)


**Entry.jsx**

- change ratio of make model/mechanisms to 55/45, change margins

    make/model:		<div style={{margin: '12px 0px 0px 0px', width: '55%', flexShrink: 0, flexDirection: 'column'}}>

	version:		<div style={{margin: '8px 0px 0px 0px', width: '40%', flexShrink: 0, flexDirection: 'column'}}>
	(width of only 40% to prevent Mechanism pill from overlapping open/close carat)

- comment out "name" to hide headers as needed

- change make/model font size, line height, margin bottom

	<Typography key={index} style={{fontWeight: 500, fontSize: '1.07rem', lineHeight: 1.25, marginBottom: '6px'}}>
		{make && make !== model ? `${make} ${model}` : model}
	</Typography>


- change version font size, line height

	value={<Typography style={{fontSize: '0.95rem', lineHeight: 1.25}}>{entry.version}</Typography>}

- Change Belt display bold and to be "beltName Belt" if no Dan Points, display "(XX Dan Pts)" for BB to prevent wrapping

		<Typography style={{marginLeft: '0px', fontSize: '1rem', lineHeight: 1.25, fontWeight: 500}}>
			{entry.belt} 
			{danPoints > 0
			? ` (${danPoints} Dan P${danPoints < 2 ? `oint` 
				: danPoints > 10 ? `ts` : `oints`})`
			: entry.belt==`Unranked` ? ``
			: ` Belt` }
		</Typography>

- remove extra space at bottom of entry details:

	<AccordionDetails sx={{padding: '8px 16px 0px 16px'}}>


TO DO: remove bottom padding from "Notes" when they appear, since they are wrapped in <p></p> by ReactMarkdown.



**FieldValue.jsx**

remove colon after name so no value won't create a space

	<div style={fullHeaderStyle}>
		{name}
	</div>



**ImageGallery.jsx**

- Add spacing above media gallery

	<ImageList variant='masonry' cols={isMobile ? 2 : 3} sx={{marginTop: 2}}>


======

(not sure why it added my .gitignore but, you can ignore it)