### PR TITLE
feat: Create CSV Export with lock "short names" instead of make & mod…

### DIFF
--- a/src/misc/ExportButton.jsx
+++ b/src/misc/ExportButton.jsx
@@ -35,6 +35,7 @@ function ExportButton() {
         return download('lpubeltsdata.json', data)
     }, [download, visibleEntries])
 
+
     const handleExportCsv = useCallback(() => {
          const csvColumns = [
             'id',
@@ -66,7 +67,8 @@ function ExportButton() {
     }, [download, visibleEntries])
 
 
-    const handleExportCsvShortNames = useCallback(() => {
+
+    const handleExportCsvShortNamesOLD = useCallback(() => {
         const csvColumns = [
             'id',
             'name',
@@ -124,6 +126,65 @@ function ExportButton() {
         const csvFile = `${headers}\n${csvData}`
         return download('lpubeltsdata.csv', csvFile)
     }, [download, visibleEntries])
+
+
+	const handleExportCsvShortNames = useCallback(() => {
+        const csvColumns = [
+            'id',
+            'name',
+            'version',
+            'belt'
+        ]
+        const shortNames = new Map()
+        visibleEntries.forEach((entry) => {
+            var lockmakes = new Map()
+            var modelsArray = []
+            var prevMake = ""
+
+            var lockShortName = ""
+            var lockSeparator = ""
+            
+            entry.makeModels.forEach((makeModel) => {
+                var thisMake = makeModel.make
+                var thisModel = makeModel.model
+                if (!thisMake) {    
+                    thisMake = thisModel
+                    thisModel = ""
+                }
+                if (prevMake == "") {
+                    lockShortName = `${thisMake} ${thisModel}`
+                } else if (thisMake == prevMake) {
+                	lockShortName += `, ${thisModel}`
+                } else {
+                    lockShortName += ` / ${thisMake} ${thisModel}`
+                }
+	            prevMake = thisMake
+            })
+            shortNames.set(entry.id, lockShortName)
+        })
+        const data = visibleEntries.map(datum => ({
+            id: datum.id,
+            make: datum.makeModels.map(e => e.make).join(','),
+            model: datum.makeModels.map(e => e.model).join(','),
+            version: datum.version,
+            belt: datum.belt,
+            name: shortNames.get(datum.id)
+        }))
+
+        const headers = csvColumns.join(',')
+        const csvData = data.map(datum => {
+            return csvColumns
+                .map(header => datum[header])
+                .map(value => {
+                    const newValue = `${value ?? ''}`.replace(/"/g, '""')
+                    return /(\s|,|")/.test(newValue) ? `"${newValue}"` : newValue
+                })
+                .join(',')
+        }).join('\n')
+        const csvFile = `${headers}\n${csvData}`
+        return download('lpubeltsdata.csv', csvFile)
+    }, [download, visibleEntries])
+
 
 
     return (


### PR DESCRIPTION
feat: Create CSV Export with lock "short names" instead of make & model data

Added handler(handleExportCsvShortNames) for exporting CSV with the short name (e.g. "ASSA Twin Combi, Triton, Neptun 4900 / TrioVing System 10, Twin Control") instead of the raw make and model data.

[lpubeltsdata-new.csv](https://github.com/Lockpickers-United/lpu-belt-explorer/files/13605904/lpubeltsdata-new.csv)
[lpubeltsdata-old.csv](https://github.com/Lockpickers-United/lpu-belt-explorer/files/13605905/lpubeltsdata-old.csv)
