### PR TITLE
feat: add 'Copy to clipboard' option to ExportButton

### DIFF
--- a/src/misc/ExportButton.jsx
+++ b/src/misc/ExportButton.jsx
@@ -32,8 +32,9 @@ function ExportButton() {
 
     const handleExportJson = useCallback(() => {
         const data = JSON.stringify(visibleEntries)
+        handleClose()
         return download('lpubeltsdata.json', data)
-    }, [download, visibleEntries])
+    }, [handleClose,download, visibleEntries])
 
     const handleExportClipboard = useCallback(() => {
         const copyToClipboard = async (clipboardText) => {
@@ -54,8 +55,9 @@ function ExportButton() {
             return '* ' + datum.name + datum.versionText
         }).join('\n')
 
+        handleClose()
         return copyToClipboard(clipboardText)
-    }, [visibleEntries])
+    }, [handleClose,visibleEntries])
 
     const handleExportCsv = useCallback(() => {
         const csvColumns = ['id', 'name', 'version', 'belt']
@@ -79,8 +81,9 @@ function ExportButton() {
                 .join(',')
         }).join('\n')
         const csvFile = `${headers}\n${csvData}`
+        handleClose()
         return download('lpubeltsdata.csv', csvFile)
-    }, [download, visibleEntries])
+    }, [handleClose,download, visibleEntries])
 
     return (
         <React.Fragment>

--- a/src/misc/ExportButton.jsx
+++ b/src/misc/ExportButton.jsx
@@ -10,6 +10,7 @@ import Tooltip from '@mui/material/Tooltip'
 import React, {useCallback, useContext, useState} from 'react'
 import DataContext from '../contexts/DataContext'
 import EntryName from '../entries/EntryName.js'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 
 function ExportButton() {
     const [anchorEl, setAnchorEl] = useState(null)
@@ -34,8 +35,30 @@ function ExportButton() {
         return download('lpubeltsdata.json', data)
     }, [download, visibleEntries])
 
+    const handleExportClipboard = useCallback(() => {
+        const copyToClipboard = async (clipboardText) => {
+            await navigator.clipboard.writeText(clipboardText)
+        }
+
+        const data = visibleEntries.map(datum => ({
+            id: datum.id,
+            make: datum.makeModels.map(e => e.make).join(','),
+            model: datum.makeModels.map(e => e.model).join(','),
+            version: datum.version,
+            belt: datum.belt,
+            name: EntryName(datum),
+            versionText: datum.version ? ' (' + datum.version + ')' : ''
+        }))
+
+        const clipboardText = data.map(datum => {
+            return '* ' + datum.name + datum.versionText
+        }).join('\n')
+
+        return copyToClipboard(clipboardText)
+    }, [visibleEntries])
+
     const handleExportCsv = useCallback(() => {
-        const csvColumns = [ 'id', 'name', 'version', 'belt' ]
+        const csvColumns = ['id', 'name', 'version', 'belt']
         const data = visibleEntries.map(datum => ({
             id: datum.id,
             make: datum.makeModels.map(e => e.make).join(','),
@@ -76,6 +99,12 @@ function ExportButton() {
                         <FileDownloadIcon fontSize='small'/>
                     </ListItemIcon>
                     <ListItemText>Export</ListItemText>
+                </MenuItem>
+                <MenuItem onClick={handleExportClipboard}>
+                    <ListItemIcon>
+                        <ContentCopyIcon fontSize='small'/>
+                    </ListItemIcon>
+                    <ListItemText>Copy to clipboard</ListItemText>
                 </MenuItem>
                 <MenuItem onClick={handleExportCsv}>
                     <ListItemIcon>

--- a/src/misc/ExportButton.jsx
+++ b/src/misc/ExportButton.jsx
@@ -37,10 +37,6 @@ function ExportButton() {
     }, [handleClose,download, visibleEntries])
 
     const handleExportClipboard = useCallback(() => {
-        const copyToClipboard = async (clipboardText) => {
-            await navigator.clipboard.writeText(clipboardText)
-        }
-
         const data = visibleEntries.map(datum => ({
             id: datum.id,
             make: datum.makeModels.map(e => e.make).join(','),
@@ -56,7 +52,7 @@ function ExportButton() {
         }).join('\n')
 
         handleClose()
-        return copyToClipboard(clipboardText)
+        navigator.clipboard.writeText(clipboardText)
     }, [handleClose,visibleEntries])
 
     const handleExportCsv = useCallback(() => {


### PR DESCRIPTION
* Adds new "Copy to clipboard" item to menu
* Copies "* EntryShortName (version if there is one)"
* Closes menu on select for all export options