### PR TITLE
Feat: Create Compact View Route (updated)

### DIFF
--- a/src/entries/CollectionButton.jsx
+++ b/src/entries/CollectionButton.jsx
@@ -1,21 +1,22 @@
 import React, {useCallback, useContext, useMemo, useState} from 'react'
+import AuthContext from '../contexts/AuthContext'
+import DBContext from '../contexts/DBContext'
 import Button from '@mui/material/Button'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import CardHeader from '@mui/material/CardHeader'
+import IconButton from '@mui/material/IconButton'
 import LibraryBooksIcon from '@mui/icons-material/LibraryBooks'
-import Tooltip from '@mui/material/Tooltip'
-import Popover from '@mui/material/Popover'
 import Checkbox from '@mui/material/Checkbox'
-import FormGroup from '@mui/material/FormGroup'
 import FormControlLabel from '@mui/material/FormControlLabel'
+import FormGroup from '@mui/material/FormGroup'
+import Popover from '@mui/material/Popover'
 import SignInButton from '../auth/SignInButton'
-import AuthContext from '../contexts/AuthContext'
-import DBContext from '../contexts/DBContext'
-import {collectionOptions} from '../data/collectionTypes'
+import Tooltip from '@mui/material/Tooltip'
 import useWindowSize from '../util/useWindowSize'
+import {collectionOptions} from '../data/collectionTypes'
 
-function CollectionButton({id}) {
+function CollectionButton({id, useIcon=false}) {
     const {isLoggedIn} = useContext(AuthContext)
     const {lockCollection, addToLockCollection, removeFromLockCollection} = useContext(DBContext)
     const [anchorEl, setAnchorEl] = useState(null)
@@ -46,18 +47,29 @@ function CollectionButton({id}) {
 
     return (
         <React.Fragment>
-            <Tooltip title='My Collection' arrow disableFocusListener>
-                <Button
-                    variant='outlined'
-                    color='inherit'
-                    onClick={handleOpen}
-                    size={isMobile ? 'small' : 'medium'}
-                    startIcon={
-                    <LibraryBooksIcon color={isCollected ? 'secondary' : 'inherit'}/>
-                }>
-                    My Collection
-                </Button>
-            </Tooltip>
+            { useIcon &&
+                <Tooltip title='My Collection' arrow disableFocusListener>
+                    <IconButton onClick={handleOpen}>
+                        <LibraryBooksIcon color={isCollected ? 'secondary' : 'inherit'}
+                                          fontSize='small'
+                        />
+                    </IconButton>
+                </Tooltip>
+            }
+            { !useIcon &&
+                <Tooltip title='My Collection' arrow disableFocusListener>
+                    <Button
+                        variant='outlined'
+                        color='inherit'
+                        onClick={handleOpen}
+                        size={isMobile ? 'small' : 'medium'}
+                        startIcon={
+                            <LibraryBooksIcon color={isCollected ? 'secondary' : 'inherit'}/>
+                        }>
+                        My Collection
+                    </Button>
+                </Tooltip>
+            }
             <Popover
                 open={open}
                 anchorEl={anchorEl}
@@ -68,7 +80,7 @@ function CollectionButton({id}) {
                 }}
             >
                 <Card>
-                    <CardHeader
+                    <CardHeader  onClick={handleClose}
                         title='My Collection'
                         style={{color: isLoggedIn ? null : 'rgba(255, 255, 255, 0.5)'}}
                     />

--- a/src/entries/CollectionFormHoriz.jsx
+++ b/src/entries/CollectionFormHoriz.jsx
@@ -1,0 +1,65 @@
+import React, {useCallback, useContext, useMemo, useState} from 'react'
+import Checkbox from '@mui/material/Checkbox'
+import FormGroup from '@mui/material/FormGroup'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import AuthContext from '../contexts/AuthContext'
+import DBContext from '../contexts/DBContext'
+import {collectionOptions} from '../data/collectionTypes'
+import useWindowSize from '../util/useWindowSize'
+import Typography from "@mui/material/Typography";
+import OpenLinkToEntryButton from "./OpenLinkToEntryButton.jsx";
+
+function CollectionFormHoriz({id}) {
+    const {isLoggedIn} = useContext(AuthContext)
+    const {lockCollection, addToLockCollection, removeFromLockCollection} = useContext(DBContext)
+    const [anchorEl, setAnchorEl] = useState(null)
+    const {width} = useWindowSize()
+    const isMobile = width <= 500
+
+    const isCollected = useMemo(() => {
+        return Object.keys(lockCollection)
+            .reduce((acc, key) => acc || lockCollection[key].includes(id), false)
+    }, [id, lockCollection])
+
+    const isChecked = useCallback(key => {
+        return !!lockCollection[key] && !!lockCollection[key].includes(id)
+    }, [id, lockCollection])
+
+    const handleChange = useCallback(key => (event, checked) => {
+        event.preventDefault()
+
+        if (checked) {
+            addToLockCollection(key, id)
+        } else {
+            removeFromLockCollection(key, id)
+        }
+    }, [id, addToLockCollection, removeFromLockCollection])
+
+    return (
+        <FormGroup row>
+            {collectionOptions.map(({key, label}) =>
+                <React.Fragment key={key}>
+                    <FormControlLabel
+                        style={{marginRight: 14}}
+                        control={
+                            <Checkbox
+                                disabled={!isLoggedIn}
+                                color='secondary'
+                                checked={isChecked(key)}
+                                onChange={handleChange(key)}
+                                size="small"
+                                style={{padding: '3px 3px 3px 8px'}}
+                            />
+                        }
+                        label={
+                            <Typography style={{fontSize: '.93rem'}}>
+                                {label}
+                            </Typography>}
+                    />
+                </React.Fragment>
+            )}
+        </FormGroup>
+    )
+}
+
+export default CollectionFormHoriz

--- a/src/entries/EntriesCompact.jsx
+++ b/src/entries/EntriesCompact.jsx
@@ -1,0 +1,77 @@
+import React, {useContext, useDeferredValue, useMemo} from 'react'
+import Entry from './Entry'
+import InlineFilterDisplay from '../filters/InlineFilterDisplay'
+import BeltRequirements from '../info/BeltRequirements'
+import DataContext from '../contexts/DataContext'
+import AppContext from '../contexts/AppContext'
+import NoEntriesCard from './NoEntriesCard'
+import InlineHeaderDisplay from './InlineHeaderDisplay'
+import InlineDisplaySpacer from './InlineDisplaySpacer.jsx'
+import FilterContext from '../contexts/FilterContext'
+import EntryList from './EntryCompact.jsx'
+import List from '@mui/material/List'
+import InlineCollectionSelect from './InlineCollectionSelect.jsx'
+
+function EntriesCompact() {
+
+    const {allEntries, visibleEntries = []} = useContext(DataContext)
+    const {tab, expanded, setExpanded, displayAll} = useContext(AppContext)
+    const {filters} = useContext(FilterContext)
+    const {filterCount} = useContext(FilterContext)
+
+    let currentCollection = ''
+    if (filters && filters.collection) {
+        currentCollection = (typeof filters.collection === 'string')
+            ? filters.collection
+            : filters.collection[0]
+    }
+
+
+    const defTab = useDeferredValue(tab)
+    const defExpanded = useDeferredValue(expanded)
+    const defDisplayAll = useDeferredValue(displayAll)
+
+    const entries = useMemo(() => {
+        if (defTab === 'search') {
+            return defDisplayAll || allEntries.length !== visibleEntries.length
+                ? visibleEntries
+                : []
+        } else {
+            return visibleEntries.filter(entry => entry.simpleBelt === defTab)
+        }
+    }, [defDisplayAll, defTab, allEntries, visibleEntries])
+
+    const style = {maxWidth: 700, marginLeft: 'auto', marginRight: 'auto', marginTop: 0}
+
+    const collectionFiltered = !!currentCollection?.match(/^(Own|Picked|Recorded|Wishlist)$/)
+    const showInlineFilterDisplay = !(collectionFiltered && filterCount < 2)
+    const showBeltRequirements = (defTab !== 'search' && !collectionFiltered && entries.length !== 0)
+
+    return (
+        <React.Fragment>
+            <div style={{margin: '0px 8px 0px 8px'}}>
+                {currentCollection && <div style={{marginTop: '8px'}}/>}
+                <InlineDisplaySpacer/>
+                <InlineHeaderDisplay/>
+                {showInlineFilterDisplay && <InlineFilterDisplay/>}
+            </div>
+
+            <div style={{
+                maxWidth: 700, marginLeft: 'auto', marginRight: 'auto',
+                padding: '8px 8px 16px 8px', backgroundColor: '#000'
+            }}>
+                {showBeltRequirements && <div><BeltRequirements belt={defTab}/></div>}
+                <InlineCollectionSelect sx={{}}/>
+                {entries.length === 0 && <NoEntriesCard/>}
+                <List style={style} dense sx={{padding: '8px 0px 8px 0px', backgroundColor: '#000'}}>
+                    {entries.map((entry, index) =>
+                        <EntryList key={entry.id} entry={entry} index={index}/>
+                    )}
+                </List>
+            </div>
+            <div style={{margin: 8, marginBottom: 24}}/>
+        </React.Fragment>
+    )
+}
+
+export default EntriesCompact

--- a/src/entries/EntryCompact.jsx
+++ b/src/entries/EntryCompact.jsx
@@ -1,0 +1,42 @@
+import React, {memo, useContext} from 'react'
+import BeltStripe from './BeltStripe'
+import CollectionButton from './CollectionButton'
+import EntryName from '../entries/EntryName.js'
+import ListItem from '@mui/material/ListItem'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
+import OpenLinkToEntryButton from './OpenLinkToEntryButton.jsx'
+import FilterContext from '../contexts/FilterContext.jsx'
+
+function EntryCompact({entry, index}) {
+    const {filters} = useContext(FilterContext)
+
+    let currentCollection = ''
+    if (filters && filters.collection) {
+        currentCollection = (typeof filters.collection === 'string')
+            ? currentCollection = filters.collection
+            : currentCollection = filters.collection[0]
+    }
+
+    function rowStyle({index}) {
+        if (!(index % 2)) { return {backgroundColor: '#111111'} }
+    }
+
+    return (
+        <ListItem style={rowStyle({index})} sx={{minHeight: 64, padding: '0px 12px 0px 24px', marginTop: '1px'}}>
+            <BeltStripe value={entry.belt}/>
+            <ListItemText
+                primary={EntryName(entry)}
+                primaryTypographyProps={{fontWeight: 500}}
+                secondary={entry.version}
+                style={{padding: '10px 0px'}}
+            />
+            <ListItemIcon style={{minWidth: 20, marginLeft: 16}}>
+                {currentCollection && <OpenLinkToEntryButton entry={entry} key={entry.id} id={entry.id}/>}
+                <CollectionButton id={entry.id} useIcon={true}/>
+            </ListItemIcon>
+        </ListItem>
+    )
+}
+
+export default React.memo(EntryCompact)

--- a/src/entries/InlineCollectionSelect.jsx
+++ b/src/entries/InlineCollectionSelect.jsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+import FilterContext from '../contexts/FilterContext'
+import useWindowSize from '../util/useWindowSize'
+import FormControl from '@mui/material/FormControl'
+import MenuItem from '@mui/material/MenuItem'
+import SortButton from '../filters/SortButton.jsx'
+import Select from '@mui/material/Select'
+import DBContext from '../contexts/DBContext.jsx'
+import {useContext} from 'react'
+
+export default function InlineCollectionSelect() {
+    const {width} = useWindowSize()
+    const style = width < 736
+        ? {maxWidth: 700}
+        : {maxWidth: 700, marginLeft: 'auto', marginRight: 'auto'}
+
+    const {filters} = useContext(FilterContext)
+    const [collection, setCollection] = React.useState('')
+    const [open, setOpen] = React.useState(false)
+    const {lockCollection} = useContext(DBContext)
+    const {setFilters, removeFilters} = useContext(FilterContext)
+    const {filterCount} = useContext(FilterContext)
+
+    let currentCollection = ''
+    if (filters && filters.collection) {
+        if (typeof filters.collection === 'string') {
+            currentCollection = filters.collection
+        } else {
+            currentCollection = filters.collection[0]
+        }
+    }
+
+    const handleClose = () => {
+        setOpen(false)
+    }
+    const handleOpen = () => {
+        setOpen(true)
+    }
+
+    const handleFilter = (filterKey, filterValue) => {
+        setFilters({
+            [filterKey]: filterValue,
+            tab: 'search'
+        })
+    }
+
+    const handleChange = (event) => {
+        handleFilter('collection', event.target.value)
+        setCollection(event.target.value)
+    }
+
+    const collectionsList = ['Own', 'Picked', 'Recorded', 'Wishlist']
+
+    if (!currentCollection || filterCount > 1) return null
+    if (!currentCollection.match(/^(Own|Picked|Recorded|Wishlist)$/)) return null
+    return (
+        <div style={style}>
+            <FormControl fullWidth size='small' sx={{marginLeft: '8px', minWidth: 80, maxWidth: 300}}>
+                <Select
+                    open={open}
+                    onClose={handleClose}
+                    onOpen={handleOpen}
+                    value={currentCollection}
+                    label=''
+                    onChange={handleChange}
+                    style={{backgroundColor: '#222', fontSize: '1.1rem', fontWeight: 500}}
+                >
+                    {collectionsList.map((list, index) =>
+                        <MenuItem key={index}
+                                  value={list}>{list} ({lockCollection[list.toLowerCase()]?.length})</MenuItem>
+                    )}
+                </Select>
+            </FormControl>
+            <SortButton/>
+        </div>
+    )
+}

--- a/src/entries/InlineDisplaySpacer.jsx
+++ b/src/entries/InlineDisplaySpacer.jsx
@@ -1,0 +1,22 @@
+import React, {useContext} from 'react'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import FilterContext from '../contexts/FilterContext'
+import useWindowSize from '../util/useWindowSize'
+
+function InlineDisplaySpacer() {
+    const {filterCount} = useContext(FilterContext)
+    const {width} = useWindowSize()
+    const style = width < 736
+        ? {maxWidth: 700}
+        : {maxWidth: 700, marginLeft: 'auto', marginRight: 'auto'}
+
+    if (!filterCount) return null
+    return (
+        <Card style={style} sx={{paddingBottom: 0, borderRadius: 0}}>
+            <CardContent style={{paddingBottom: 0}}/>
+        </Card>
+    )
+}
+
+export default InlineDisplaySpacer

--- a/src/entries/InlineHeaderDisplay.jsx
+++ b/src/entries/InlineHeaderDisplay.jsx
@@ -1,0 +1,43 @@
+import React, {useContext} from 'react'
+import Card from '@mui/material/Card'
+import CardActions from '@mui/material/CardActions'
+import CardContent from '@mui/material/CardContent'
+import FilterContext from '../contexts/FilterContext'
+import useWindowSize from '../util/useWindowSize'
+import ClearFiltersButton from '../filters/ClearFiltersButton.jsx'
+
+function InlineHeaderDisplay() {
+    const {width} = useWindowSize()
+    const style = width < 736
+        ? {maxWidth: 700}
+        : {maxWidth: 700, marginLeft: 'auto', marginRight: 'auto'}
+
+    const {filters} = useContext(FilterContext)
+    const {filterCount} = useContext(FilterContext)
+
+    let currentCollection = ''
+    if (filters && filters.collection) {
+        if (typeof filters.collection === 'string') {
+            currentCollection = filters.collection
+        } else {
+            currentCollection = filters.collection[0]
+        }
+    }
+
+    if (!currentCollection) return null
+    if (!currentCollection.match(/^(Own|Picked|Recorded|Wishlist)$/)) return null
+    return (
+        <Card style={style} sx={{borderRadius: 0}}>
+            <CardContent style={{fontSize: '1.48rem', paddingBottom: 0, paddingTop: 0, float: 'left'}}>
+                <span style={{fontWeight: 500}}>My Collection</span>
+            </CardContent>
+            <CardActions style={{paddingTop: 0, float: 'right'}}>
+                {filterCount < 2 &&
+                    <ClearFiltersButton/>
+                }
+            </CardActions>
+        </Card>
+    )
+}
+
+export default InlineHeaderDisplay

--- a/src/entries/NoEntriesCard.jsx
+++ b/src/entries/NoEntriesCard.jsx
@@ -9,7 +9,14 @@ import Button from '@mui/material/Button'
 function NoEntriesCard() {
     const {tab} = useContext(AppContext)
     const defTab = useDeferredValue(tab)
-    const style = {marginTop: 16, maxWidth: 700, marginLeft: 'auto', marginRight: 'auto'}
+    const style = {
+        marginTop: 16,
+        marginBottom: 0,
+        maxWidth: 700,
+        marginLeft: 'auto',
+        marginRight: 'auto',
+        borderRadius: 0
+    }
     const {setDisplayAll} = useContext(AppContext)
 
     const isSearchTab = defTab === 'search'
@@ -23,7 +30,7 @@ function NoEntriesCard() {
 
     return (
         <Card style={style}>
-            <CardContent style={{paddingBottom: 8}}>
+            <CardContent style={{paddingBottom: 16}}>
                 <Typography variant='h6' align='center'>
                     {message}
                 </Typography>

--- a/src/entries/OpenLinkToEntryButton.jsx
+++ b/src/entries/OpenLinkToEntryButton.jsx
@@ -1,0 +1,37 @@
+import React, {useCallback, useContext, useMemo} from 'react'
+import Tooltip from '@mui/material/Tooltip'
+import DataContext from '../contexts/DataContext'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import AppContext from '../contexts/AppContext'
+import FilterContext from '../contexts/FilterContext'
+import IconButton from '@mui/material/IconButton'
+import OpenInFullIcon from '@mui/icons-material/OpenInFull';
+
+console.log('OpenLinkToEntryButton start')
+
+function OpenLinkToEntryButton({id}) {
+    const {setExpanded, setExpandedDirect} = useContext(AppContext)
+    const {getEntryFromId, getNameFromId, visibleEntries} = useContext(DataContext)
+    const {setFilters} = useContext(FilterContext)
+    const entry = useMemo(() => getEntryFromId(id), [getEntryFromId, id])
+
+    const handleClick = useCallback(async () => {
+        if (id) {
+            const name = getNameFromId(id)
+            setFilters({id, name, tab: entry.belt.replace(/\s\d/g, '')})
+            setExpandedDirect(id)
+        }
+    }, [visibleEntries, id, getNameFromId, setFilters, entry.belt, setExpanded, setExpandedDirect])
+
+    return (
+        <Tooltip title='View Full Entry' arrow disableFocusListener>
+            <IconButton onClick={handleClick}>
+                <OpenInNewIcon fontSize='small'/>
+            </IconButton>
+        </Tooltip>
+    )
+}
+
+console.log('OpenLinkToEntryButton end')
+
+export default OpenLinkToEntryButton

--- a/src/info/BeltRequirements.jsx
+++ b/src/info/BeltRequirements.jsx
@@ -11,6 +11,7 @@ import InfoButton from './InfoButton'
 import AppContext from '../contexts/AppContext'
 import LinkToRequirementsButton from './LinkToRequirementsButton'
 import beltRequirements from '../data/beltRequirements'
+
 import DataContext from '../contexts/DataContext'
 
 function BeltRequirements({belt}) {
@@ -20,7 +21,9 @@ function BeltRequirements({belt}) {
         setExpanded(isExpanded ? 'beltreqs' : false)
         window.scrollTo({top: 0, behavior: 'smooth'})
     }, [setExpanded])
-    const style = {maxWidth: 700, marginLeft: 'auto', marginRight: 'auto'}
+    const style = {
+        maxWidth: 700, marginLeft: 'auto', marginRight: 'auto', borderRadius: 0
+    }
     const markdown = beltRequirements[belt]
 
     if (!markdown || (!visibleEntries.length > 0)) return null
@@ -28,7 +31,7 @@ function BeltRequirements({belt}) {
         <Accordion expanded={expanded === 'beltreqs'} onChange={handleExpand} style={style}>
             <AccordionSummary expandIcon={<ExpandMoreIcon/>}>
                 <BeltStripe value={belt}/>
-                <Typography variant='h6' style={{margin: '0px 0px 0px 12px'}}>{belt} Belt Requirements</Typography>
+                <Typography variant="h6" style={{margin: '0px 0px 0px 12px'}}>{belt} Belt Requirements</Typography>
             </AccordionSummary>
             <AccordionDetails style={{margin: '0px 0px 0px 12px'}}>
                 <ReactMarkdown>

--- a/src/nav/Nav.jsx
+++ b/src/nav/Nav.jsx
@@ -7,7 +7,7 @@ import Tracker from '../app/Tracker'
 import ScrollToTopButton from './ScrollToTopButton'
 import UserMenu from './UserMenu'
 
-function Nav({extras, title}) {
+function Nav({extras,title}) {
     return (
         <React.Fragment>
             <AppBar position='fixed' sx={{boxShadow: 'none'}}>
@@ -16,7 +16,7 @@ function Nav({extras, title}) {
 
                     <HomeButton/>
 
-                    <div style={{flexGrow: 1, fontWeight: 500, fontSize: '1.7rem'}}>{title}</div>
+                    <div style={{flexGrow: 1, fontWeight: 500, fontSize: '1.5rem'}}>{title}</div>
 
                     <VersionChecker/>
 

--- a/src/nav/UserMenu.jsx
+++ b/src/nav/UserMenu.jsx
@@ -30,6 +30,11 @@ function UserMenu() {
     const handleClose = useCallback(() => setAnchorEl(null), [])
 
     const handleClick = useCallback(url => () => {
+        const currentRoute = window.location.href.match(/#\/(\w*)/i)[1]
+        const urlRoute = url.match(/\/(\w*)/i)[1]
+        if (currentRoute.match(/(belt|compact)/) && urlRoute.match(/(belt|compact)/)) {
+            url = url.replace(urlRoute, currentRoute)
+        }
         handleClose()
         navigate(url)
     }, [handleClose, navigate])
@@ -48,7 +53,7 @@ function UserMenu() {
                             ? <Avatar
                                 alt={user.displayName}
                                 src={user.photoURL}
-                                sx={{ width: 24, height: 24 }}
+                                sx={{width: 24, height: 24}}
                             />
                             : <AccountCircleIcon/>
                     }

--- a/src/routes/CompactRoute.jsx
+++ b/src/routes/CompactRoute.jsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import BeltToolbar from '../nav/BeltToolbar'
+import EntriesCompact from '../entries/EntriesCompact.jsx'
+import ExportButton from '../misc/ExportButton'
+import FilterButton from '../filters/FilterButton'
+import Footer from '../nav/Footer'
+import HotkeyInfoButton from '../misc/HotkeyInfoButton'
+import InfoButton from '../info/InfoButton'
+import Nav from '../nav/Nav'
+import RandomEntryButton from '../misc/RandomEntryButton'
+import SearchBox from '../nav/SearchBox'
+import SlideshowButton from '../misc/SlideshowButton'
+import SortButton from '../filters/SortButton'
+import {AppProvider} from '../contexts/AppContext'
+import {DataProvider} from '../contexts/DataContext'
+import {FilterProvider} from '../contexts/FilterContext'
+import {LazyDataProvider} from '../contexts/LazyDataContext'
+
+
+function CompactRoute() {
+    const nav = (
+        <React.Fragment>
+            <SearchBox/>
+
+            <div style={{flexGrow: 1}}></div>
+
+            <InfoButton icon/>
+            <SortButton/>
+            <FilterButton/>
+        </React.Fragment>
+    )
+    const footer = (
+        <React.Fragment>
+            <br/>
+            <HotkeyInfoButton/>&nbsp;•&nbsp;
+            <RandomEntryButton/>&nbsp;•&nbsp;
+            <ExportButton/>&nbsp;•&nbsp;
+            <SlideshowButton/>
+        </React.Fragment>
+    )
+
+    return (
+        <LazyDataProvider>
+            <FilterProvider>
+                <DataProvider>
+                    <AppProvider>
+                        <Nav extras={nav}/>
+                        <BeltToolbar/>
+
+                        <EntriesCompact/>
+
+                        <Footer extras={footer}/>
+                    </AppProvider>
+                </DataProvider>
+            </FilterProvider>
+        </LazyDataProvider>
+    )
+}
+
+export default CompactRoute

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {redirect} from 'react-router-dom'
 import BeltList from './BeltList'
 import LeaderboardRoute from './LeaderboardRoute.jsx'
+import CompactRoute from "./CompactRoute.jsx";
 
 export default [
     {
@@ -11,6 +12,10 @@ export default [
     {
         path: '/belts',
         element: <BeltList/>
+    },
+    {
+        path: '/compact',
+        element: <CompactRoute/>
     },
     {
         path: '/leaderboard',


### PR DESCRIPTION
- create new route
- currently only visible through /#/compact
- new entries/entry styles
- enhancements to inline filter and header display
- update UserNav to retain route for /belts and /compact