### PR TITLE
UI: Updates to Compact mode display

### DIFF
--- a/src/entries/CollectionButton.jsx
+++ b/src/entries/CollectionButton.jsx
@@ -54,17 +54,15 @@ function CollectionButton({id, dense}) {
                             variant='outlined'
                             color='inherit'
                             onClick={handleOpen}
-                            size={isMobile ? 'small' : 'medium'}
                             >
-                            <LibraryBooksIcon color={isCollected ? 'secondary' : 'inherit'}/>
+                            <LibraryBooksIcon color={isCollected ? 'secondary' : 'inherit'} fontSize='small'/>
                         </IconButton>
                         : <Button
                             variant='outlined'
                             color='inherit'
                             onClick={handleOpen}
-                            size={isMobile ? 'small' : 'medium'}
                             startIcon={
-                                <LibraryBooksIcon color={isCollected ? 'secondary' : 'inherit'}/>
+                                <LibraryBooksIcon color={isCollected ? 'secondary' : 'inherit'} fontSize={isMobile ? 'small' : 'medium'}/>
                             }>
                             My Collection
                         </Button>
@@ -84,6 +82,7 @@ function CollectionButton({id, dense}) {
                     <CardHeader
                         title='My Collection'
                         style={{color: isLoggedIn ? null : 'rgba(255, 255, 255, 0.5)'}}
+                        onClick={handleClose}
                     />
                     <CardContent style={{paddingTop: 0}}>
                         <FormGroup>

--- a/src/entries/CompactEntries.jsx
+++ b/src/entries/CompactEntries.jsx
@@ -7,20 +7,22 @@ import React from 'react'
 import BeltStripe from './BeltStripe'
 import CollectionButton from './CollectionButton'
 import EntryName from './EntryName'
+import Divider from '@mui/material/Divider'
 
 function CompactEntries({entries}) {
     return (
         <Card style={{maxWidth: 700, marginLeft: 'auto', marginRight: 'auto', borderRadius: 0}}>
-            <List dense style={{paddingTop: 0}}>
+            <List dense style={{padding: 0}}>
                 {entries.map(entry =>
-                    <ListItem key={entry.id} sx={{minHeight: 64, borderTop: '1px solid rgba(255, 255, 255, 0.12)'}}>
+                    <ListItem key={entry.id}
+                              style = {{minHeight: 64, borderTop: '1px solid rgba(255, 255, 255, 0.12)'}}>
                         <BeltStripe value={entry.belt}/>
 
                         <ListItemText
                             primary={EntryName(entry)}
                             primaryTypographyProps={{fontWeight: 500}}
                             secondary={entry.version}
-                            style={{padding: '10px 0px'}}
+                            style={{padding: '0px 0px 0px 10px'}}
                         />
 
                         <ListItemIcon style={{minWidth: 20, marginLeft: 16}}>
@@ -29,6 +31,7 @@ function CompactEntries({entries}) {
                     </ListItem>
                 )}
             </List>
+            <Divider/>
         </Card>
     )
 }

--- a/src/entries/Entries.jsx
+++ b/src/entries/Entries.jsx
@@ -6,6 +6,7 @@ import BeltRequirements from '../info/BeltRequirements'
 import DataContext from '../contexts/DataContext'
 import AppContext from '../contexts/AppContext'
 import NoEntriesCard from './NoEntriesCard'
+import InlineCollectionSelect from './InlineCollectionSelect.jsx'
 
 function Entries() {
     const {compact, tab, expanded, setExpanded, displayAll} = useContext(AppContext)
@@ -29,8 +30,9 @@ function Entries() {
         <React.Fragment>
             <div style={{margin: 8, paddingBottom: 32}}>
                 <InlineFilterDisplay/>
+                <InlineCollectionSelect/>
 
-                {defTab !== 'search' && <BeltRequirements belt={defTab}/>}
+                {(defTab !== 'search' && entries.length !== 0) && <BeltRequirements belt={defTab}/>}
 
                 {entries.length === 0 && <NoEntriesCard/>}
 

--- a/src/entries/InlineCollectionSelect.jsx
+++ b/src/entries/InlineCollectionSelect.jsx
@@ -1,0 +1,78 @@
+import * as React from 'react'
+import FilterContext from '../contexts/FilterContext'
+import useWindowSize from '../util/useWindowSize'
+import FormControl from '@mui/material/FormControl'
+import MenuItem from '@mui/material/MenuItem'
+import SortButton from '../filters/SortButton.jsx'
+import Select from '@mui/material/Select'
+import DBContext from '../contexts/DBContext.jsx'
+import {useContext} from 'react'
+import Card from '@mui/material/Card'
+
+export default function InlineCollectionSelect() {
+    const {width} = useWindowSize()
+    const style = width < 736
+        ? {maxWidth: 700, borderRadius: 0}
+        : {maxWidth: 700, marginLeft: 'auto', marginRight: 'auto', borderRadius: 0}
+
+    const {filters} = useContext(FilterContext)
+    const [setCollection] = React.useState('')
+    const [open, setOpen] = React.useState(false)
+    const {lockCollection} = useContext(DBContext)
+    const {setFilters} = useContext(FilterContext)
+    const {filterCount} = useContext(FilterContext)
+
+    let currentCollection = ''
+    if (filters && filters.collection) {
+        if (typeof filters.collection === 'string') {
+            currentCollection = filters.collection
+        } else {
+            currentCollection = filters.collection[0]
+        }
+    }
+
+    const handleClose = () => {
+        setOpen(false)
+    }
+    const handleOpen = () => {
+        setOpen(true)
+    }
+
+    const handleFilter = (filterKey, filterValue) => {
+        setFilters({
+            [filterKey]: filterValue,
+            tab: 'search'
+        })
+    }
+
+    const handleChange = (event) => {
+        handleFilter('collection', event.target.value)
+        setCollection(event.target.value)
+    }
+
+    const collectionsList = ['Own', 'Picked', 'Recorded', 'Wishlist']
+
+    if (!currentCollection || filterCount > 1) return null
+    if (!currentCollection.match(/^(Own|Picked|Recorded|Wishlist)$/)) return null
+    return (
+        <Card style={style} sx={{padding: '0px 0px 16px 14px'}}>
+            <FormControl fullWidth size='small' sx={{marginLeft: '8px', minWidth: 80, maxWidth: 300}}>
+                <Select
+                    open={open}
+                    onClose={handleClose}
+                    onOpen={handleOpen}
+                    value={currentCollection}
+                    label=''
+                    onChange={handleChange}
+                    style={{backgroundColor: '#222', fontSize: '1.1rem', fontWeight: 500}}
+                >
+                    {collectionsList.map((list, index) =>
+                        <MenuItem key={index}
+                                  value={list}>{list} ({lockCollection[list.toLowerCase()]?.length})</MenuItem>
+                    )}
+                </Select>
+            </FormControl>
+            <SortButton/>
+        </Card>
+    )
+}

--- a/src/filters/FilterButton.jsx
+++ b/src/filters/FilterButton.jsx
@@ -59,7 +59,7 @@ function FilterButton({data}) {
                 onOpen={openDrawer}
                 onClose={closeDrawer}
             >
-                <Toolbar variant='dense'>
+                <Toolbar variant='dense'  onClick={closeDrawer}>
                     <Typography variant='h6'>Filters</Typography>
                 </Toolbar>
                 <Box margin={1}>

--- a/src/filters/InlineFilterDisplay.jsx
+++ b/src/filters/InlineFilterDisplay.jsx
@@ -4,7 +4,6 @@ import Card from '@mui/material/Card'
 import CardActions from '@mui/material/CardActions'
 import CardContent from '@mui/material/CardContent'
 import AuthContext from '../contexts/AuthContext'
-import DBContext from '../contexts/DBContext'
 import FilterDisplay from './FilterDisplay'
 import FilterContext from '../contexts/FilterContext'
 import ClearFiltersButton from './ClearFiltersButton'
@@ -13,23 +12,44 @@ import useWindowSize from '../util/useWindowSize'
 function InlineFilterDisplay() {
     const {isLoggedIn} = useContext(AuthContext)
     const {filters, filterCount} = useContext(FilterContext)
-    const {lockCollection} = useContext(DBContext)
 
     const {collection} = filters
     const {width} = useWindowSize()
     const style = width < 736
-        ? {maxWidth: 700}
-        : {maxWidth: 700, marginLeft: 'auto', marginRight: 'auto'}
+        ? {maxWidth: 700, borderRadius: 0}
+        : {maxWidth: 700, marginLeft: 'auto', marginRight: 'auto', borderRadius: 0}
+
+    let currentCollection = ''
+    if (filters && filters.collection) {
+        if (typeof filters.collection === 'string') {
+            currentCollection = filters.collection
+        } else {
+            currentCollection = filters.collection[0]
+        }
+    }
 
     let header
     if (isLoggedIn && typeof collection === 'string') {
-        const title = `Collection: ${collection} (${lockCollection[collection.toLowerCase()]?.length || 0})`
-        header = <CardHeader title={title}/>
+        header = <CardHeader title='My Collection' style={{}}/>
     }
 
     if (!filterCount) return null
+    if (currentCollection && currentCollection.match(/^(Own|Picked|Recorded|Wishlist)$/) && filterCount === 1)
+        return (
+            <Card style={style} sx={{padding: '16px 0px 8px 8px'}}>
+                <CardContent style={{fontSize: '1.48rem', paddingBottom: 0, paddingTop: 0, float: 'left'}}>
+                    <span style={{fontWeight: 500}}>My Collection</span>
+                </CardContent>
+                <CardActions style={{paddingTop: 0, marginRight: '8px', float: 'right'}}>
+                    {filterCount < 2 &&
+                        <ClearFiltersButton/>
+                    }
+                </CardActions>
+            </Card>
+        )
+
     return (
-        <Card style={style} sx={{paddingBottom: 0, paddingTop: 0, borderRadius: 0}}>
+        <Card style={style} sx={{paddingBottom: 0, paddingTop: 0}}>
             {header}
             <CardContent style={{paddingBottom: 0, paddingTop: 0}}>
                 <FilterDisplay/>

--- a/src/info/BeltRequirements.jsx
+++ b/src/info/BeltRequirements.jsx
@@ -23,7 +23,7 @@ function BeltRequirements({belt}) {
     const style = {maxWidth: 700, marginLeft: 'auto', marginRight: 'auto', borderRadius: 0}
     const markdown = beltRequirements[belt]
 
-    if (!markdown || (!visibleEntries.length > 0)) return null
+    if (!markdown) return null
     return (
         <Accordion expanded={expanded === 'beltreqs'} onChange={handleExpand} style={style}>
             <AccordionSummary expandIcon={<ExpandMoreIcon/>}>


### PR DESCRIPTION
Updates include
- add inline collection selector (if active collection, no other filters. also appears in standard view)
- small collection icon when in compact mode
- adjust spacing in entry display
- do not display belt requirements if no visible entries
- click on headers of filter drawer and collection card header close them