### PR TITLE
feat: Allow switching between local and prod data for stats pages.

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_LOCAL_DATA=false

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -45,7 +45,8 @@ module.exports = {
                 json: 'always'
             }
         ],
-        'import/no-unresolved': 'off'
+        'import/no-unresolved': 'off',
+        'import/namespace': 'off'
     },
     ignorePatterns: [
         '*.md',

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ scripts/*.md
 public/version.json
 public/sitemap.txt
 public/sitemap.xml
+public/data/*

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "generateSitemap": "node ./scripts/generateSitemap.js",
         "generateSitemap-xml": "node ./scripts/generateSitemap-xml.js",
         "versionFile": "node ./scripts/version.js",
+        "copyData": "node ./scripts/copyData.js",
         "copyFiles": "node ./scripts/copyFiles.js",
         "ci-pr": "yarn lint && yarn build",
         "ci-build": "yarn versionFile && yarn generateSitemap && yarn generateSitemap-xml && yarn run build && yarn exportMd && yarn exportCsv && yarn exportHtml && yarn copyFiles"

--- a/scripts/copyData.js
+++ b/scripts/copyData.js
@@ -1,0 +1,23 @@
+import fs from 'fs'
+import fetch from 'node-fetch'
+import * as dataUrls from '../src/data/dataUrls.js'
+import path from 'path'
+
+if (!fs.existsSync('./public/data')) fs.mkdirSync('./public/data')
+
+const promises = Object.keys(dataUrls).map(async key => {
+    const url = dataUrls[key]
+    const fileName = path.parse(url).base
+    const fullPath = path.join('./public/data', fileName)
+
+    console.log('Fetching', url)
+    const response = await fetch(url)
+    const data = await response.json()
+
+    console.log('Writing local data', fullPath)
+    fs.writeFileSync(fullPath, JSON.stringify(data))
+})
+
+await Promise.all(promises)
+
+console.log('Done')

--- a/src/admin/CollectionsReportMain.jsx
+++ b/src/admin/CollectionsReportMain.jsx
@@ -10,9 +10,10 @@ import CollectionsListCountsLine from './CollectionsListCountsLine'
 import CollectionSavesByBeltBar from './CollectionSavesByBeltBar'
 import CollectionsLast28Table from './CollectionsLast28Table'
 import TopLocks from './collectionsReport/TopLocks'
+import {collectionsFull} from '../data/dataUrls'
 
 function CollectionsReportMain() {
-    const {data, loading, error} = useData({url})
+    const {data, loading, error} = useData({url: collectionsFull})
 
     const updateTime = loading ? '--'
         : '(updated: ' + dayjs(data.metadata.updatedDateTime).format('MM/DD/YY hh:mm') + ` ${data.metadata.timezone})`
@@ -79,7 +80,5 @@ function CollectionsReportMain() {
         </div>
     )
 }
-
-const url = 'https://explore.lpubelts.com/data/statsCollectionsFull.json'
 
 export default CollectionsReportMain

--- a/src/admin/SiteReportMain.jsx
+++ b/src/admin/SiteReportMain.jsx
@@ -7,6 +7,7 @@ import FirstVisitsLastSevenTable from './siteReport/FirstVisitsLastSevenTable'
 import PageTrackingTable from './siteReport/PageTrackingTable'
 import SiteReportSummary from './siteReport/SiteReportSummary'
 import dayjs from 'dayjs'
+import {siteFull, siteSummary} from '../data/dataUrls'
 
 function SiteReportMain() {
     const {data, loading, error} = useData({urls})
@@ -60,8 +61,8 @@ function SiteReportMain() {
 }
 
 const urls = {
-    siteFull: 'https://explore.lpubelts.com/data/statsSiteFull.json',
-    siteSummary: 'https://explore.lpubelts.com/data/statsSiteSummary.json'
+    siteFull,
+    siteSummary
 }
 
 export default SiteReportMain

--- a/src/data/dataUrls.js
+++ b/src/data/dataUrls.js
@@ -1,0 +1,16 @@
+const url = import.meta.env && import.meta.env.VITE_LOCAL_DATA === 'true'
+    ? 'http://localhost:3000/data'
+    : 'https://explore.lpubelts.com/data'
+
+if (import.meta.env && import.meta.env.VITE_LOCAL_DATA === 'true') {
+    console.info('Attention: App is using LOCAL DATA.')
+}
+
+export const brandDistribution = `${url}/statsBrandDistribution.json`
+export const collectionsFull = `${url}/statsCollectionsFull.json`
+export const collectionsSummary = `${url}/statsCollectionsSummary.json`
+export const lockSummary = `${url}/statsLockSummary.json`
+export const popularAreas = `${url}/statsPopularAreas.json`
+export const redditGrowth = `${url}/statsRedditGrowth.json`
+export const siteFull = `${url}/statsSiteFull.json`
+export const siteSummary = `${url}/statsSiteSummary.json`

--- a/src/stats/StatsRoute.jsx
+++ b/src/stats/StatsRoute.jsx
@@ -5,6 +5,14 @@ import Nav from '../nav/Nav'
 import LoadingDisplay from '../util/LoadingDisplay'
 import useData from '../util/useData'
 import StatsMainPage from './StatsMainPage'
+import {
+    brandDistribution,
+    collectionsSummary,
+    lockSummary,
+    popularAreas,
+    redditGrowth,
+    siteSummary
+} from '../data/dataUrls'
 
 function StatsRoute() {
     const {data, loading, error} = useData({urls})
@@ -24,12 +32,12 @@ function StatsRoute() {
 }
 
 const urls = {
-    brandDistribution: 'https://explore.lpubelts.com/data/statsBrandDistribution.json',
-    collectionsSummary: 'https://explore.lpubelts.com/data/statsCollectionsSummary.json',
-    lockSummary: 'https://explore.lpubelts.com/data/statsLockSummary.json',
-    popularAreas: 'https://explore.lpubelts.com/data/statsPopularAreas.json',
-    redditGrowth: 'https://explore.lpubelts.com/data/statsRedditGrowth.json',
-    siteSummary: 'https://explore.lpubelts.com/data/statsSiteSummary.json'
+    brandDistribution,
+    collectionsSummary,
+    lockSummary,
+    popularAreas,
+    redditGrowth,
+    siteSummary
 }
 
 export default StatsRoute


### PR DESCRIPTION
To begin, run `yarn run copyData` which will copy all referenced data files to your local `public/data` folder. Then, if you want to run against these files, make a file named `.env.local` in the root of the project, and add a line `VITE_LOCAL_DATA=true`. You can switch this value from false to true as much as you like and even while the app is running.