### PR TITLE
Fix back button behavior around scorecard.

### DIFF
--- a/src/context/FilterContext.jsx
+++ b/src/context/FilterContext.jsx
@@ -21,7 +21,7 @@ export function FilterProvider({children, filterFields = []}) {
                     delete newFilters[key]
                 }
             })
-        setSearchParams(newFilters)
+        setSearchParams(newFilters, {replace: true})
     }, [setSearchParams])
 
     const addFilters = useCallback((keyValues, replace) => {
@@ -47,7 +47,7 @@ export function FilterProvider({children, filterFields = []}) {
                 searchParams.delete(key)
             }
         })
-        setSearchParams(searchParams)
+        setSearchParams(searchParams, {replace: true})
     }, [searchParams, setSearchParams])
 
     const addFilter = useCallback((keyToAdd, valueToAdd, replace) => {
@@ -56,7 +56,7 @@ export function FilterProvider({children, filterFields = []}) {
 
     const removeFilters = useCallback(keysToDelete => {
         keysToDelete.forEach(key => searchParams.delete(key))
-        setSearchParams(searchParams)
+        setSearchParams(searchParams, {replace: true})
     }, [searchParams, setSearchParams])
 
     const removeFilter = useCallback((keyToDelete, valueToDelete) => {
@@ -67,7 +67,7 @@ export function FilterProvider({children, filterFields = []}) {
             const newValue = currentValue.filter(value => value !== valueToDelete)
             newValue.forEach(v => searchParams.append(keyToDelete, v))
         }
-        setSearchParams(searchParams)
+        setSearchParams(searchParams, {replace: true})
     }, [searchParams, setSearchParams])
 
     const clearFilters = useCallback(() => {

--- a/src/profile/ViewProfileRoute.jsx
+++ b/src/profile/ViewProfileRoute.jsx
@@ -16,7 +16,7 @@ function ViewProfileRoute() {
 
     useEffect(() => {
         if (authLoaded && user) {
-            navigate(`/profile/${user.uid}`)
+            navigate(`/profile/${user.uid}`, {replace: true})
         }
     }, [authLoaded, navigate, user])
 

--- a/src/scorecard/ViewScorecardRoute.jsx
+++ b/src/scorecard/ViewScorecardRoute.jsx
@@ -17,7 +17,7 @@ function ViewScorecardRoute({mostPopular}) {
     const subdir = mostPopular ? '/popular' : ''
     useEffect(() => {
         if (authLoaded && user) {
-            navigate(`/profile/${user.uid}/scorecard${subdir}`)
+            navigate(`/profile/${user.uid}/scorecard${subdir}`, {replace: true})
         }
     }, [authLoaded, navigate, subdir, user])
 


### PR DESCRIPTION
# Problem
1. From the main route (or leaderboards), navigate to a/your scorecard. 
3. Hit the browser back button
4. Expected Results: goes back to main route.
5. Actual: Multiple back button presses required.

# Solution
Several instances of `navigate()` usage were not using the `replace: true` option. Thus they would make multiple history entries unintentionally. This change has the effect that filter changes don't make new history entries.